### PR TITLE
Fix: Correct syntax error in main.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,3 +1,3 @@
 a = 5
 b = 3
-print(a+)
+print(a+b)


### PR DESCRIPTION
This pull request fixes a syntax error in main.py by correcting the line `print(a+)` to `print(a+b)`.